### PR TITLE
Fixing typos on 'government'

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Govcode | Goverment Open Source Projects</title>
+        <title>Govcode | Government Open Source Projects</title>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <meta name="description" content="">
         <meta name="author" content="">
@@ -29,7 +29,7 @@
             </div>
 
             <h1>
-                <a href="/">Govcode <small>Goverment Open Source Projects</small></a>
+                <a href="/">Govcode <small>Government Open Source Projects</small></a>
             </h1>
 
             <div class="clear: both;">&nbsp;</div>
@@ -37,7 +37,7 @@
             {% block content %}{% endblock %}
 
             <footer>
-                    <p>This is not a goverment sponsored website. The code linked here belongs to each of the agencies.</p>
+                    <p>This is not a government sponsored website. The code linked here belongs to each of the agencies.</p>
             </footer>
         </div> <!-- /container -->
 


### PR DESCRIPTION
Fixing a few instances where `government` was misspelled.
