### PR TITLE
Ensure that date-calculated fields always have an int64 value. Fixes #23

### DIFF
--- a/govcoded/main.go
+++ b/govcoded/main.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"time"
+
 	c "github.com/dlapiduz/govcode.org/common"
 	"github.com/go-martini/martini"
 	"github.com/martini-contrib/cors"
 	"github.com/martini-contrib/gzip"
 	"github.com/martini-contrib/render"
-	"time"
 )
 
 func main() {
@@ -51,8 +52,8 @@ func ReposIndex(r render.Render) {
 	var results []c.Repository
 	rows := c.DB.Table("repositories")
 	rows = rows.Select(`repositories.*, organizations.login as organization_login,
-		date_part('day', now() - last_pull) as days_since_pull,
-		date_part('day', now() - last_commit) as days_since_commit
+		coalesce(date_part('day', now() - last_pull), -1) as days_since_pull,
+		coalesce(date_part('day', now() - last_commit), -1) as days_since_commit
 		`)
 	rows = rows.Joins("inner join organizations on organizations.id = repositories.organization_id")
 	rows.Scan(&results)


### PR DESCRIPTION
I hit a problem with import -- still unresolved -- that caused repos to be brought in with null last_commit and last_pull dates. last_pull being null seems like a valid thing to me, though last_commit probably wouldn't be under normal circumstances.

Anyway, in that case, the calcs for the last_pull and last_commit values were returning null because the fields didn't have values, and that was causing the UI to be empty, due to the scan error described in #23 .  This ensures that even in the aberrant case of null values, the UI still works as expected
