### PR TITLE
Use responsive col-sm-4 on homepage

### DIFF
--- a/front/app/views/home.html
+++ b/front/app/views/home.html
@@ -14,19 +14,19 @@
     <div class="stats col-md-6 col-md-offset-3">
       <div class="row-fluid">
 
-        <div class="stat col-xs-4">
+        <div class="stat col-sm-4">
           <a ng-href="/contributors">
             <span>{{ home_stats.UserCount }}</span>
             <p>Contributors</p>
           </a>
         </div>
-        <div class="stat col-xs-4">
+        <div class="stat col-sm-4">
           <a ng-href="/repos">
             <span>{{ home_stats.RepoCount }}</span>
             <p>Projects</p>
           </a>
         </div>
-        <div class="stat col-xs-4">
+        <div class="stat col-sm-4">
           <a ng-href="/issues">
             <span>{{ home_stats.IssueCount }}</span>
             <p>Issues</p>
@@ -54,7 +54,7 @@
   <div style="clear:both;">&nbsp;</div>
 
   <div class="row-fluid latest">
-    <div class="col-xs-4">
+    <div class="col-sm-4">
       <h5>Latest Projects</h5>
       <div class="latest-repos card" ng-repeat="repo in latestRepos">
         <div class="card-head">
@@ -67,7 +67,7 @@
         </p>
       </div>
     </div>
-    <div class="col-xs-4">
+    <div class="col-sm-4">
       <h5>Latest Issues</h5>
       <div class="latest-issues card issue" ng-repeat="issue in latestIssues">
         <p>
@@ -84,7 +84,7 @@
         </div>
       </div>
     </div>
-    <div class="col-xs-4">
+    <div class="col-sm-4">
       <h5>Help Wanted Issues</h5>
       <div class="help-wanted-issues card issue" ng-repeat="issue in helpWantedIssues">
         <p>


### PR DESCRIPTION
Bootstrap's col-xs-* classes are always rendered horizontally - the stats and issues columns were causing smartphone-sized displays to break the rest of the layout:
![img_0847](https://cloud.githubusercontent.com/assets/618426/6013177/41c0b800-ab0e-11e4-80cc-03afa30ddd8b.PNG) ![img_0846](https://cloud.githubusercontent.com/assets/618426/6013176/41bf7526-ab0e-11e4-835b-990aae8c1c2a.PNG)

I switched them to col-sm , which stacks them vertically for "xs"-sized devices and goes back to horizontal for larger ones.

I used http://getbootstrap.com/css/#grid-options for reference.
